### PR TITLE
Added the puppetlabs apt repo

### DIFF
--- a/manifests/dependencies.pp
+++ b/manifests/dependencies.pp
@@ -18,6 +18,9 @@ class activemq::dependencies {
     'centos','redhat','scientific': {
       require yum::repo::puppetlabs
     }
+    /(?i:Debian|Ubuntu|Mint)/ : {
+      require apt::repo::puppetlabs
+    }
     default: {}
   }
 


### PR DESCRIPTION
A simple fix - added the missing apt repo to the dependencies.
Fixes #2 
